### PR TITLE
fix call to shortDisplayName on null in MuninPluginController

### DIFF
--- a/app/Http/Controllers/Select/MuninPluginController.php
+++ b/app/Http/Controllers/Select/MuninPluginController.php
@@ -42,7 +42,7 @@ class MuninPluginController extends SelectController
             ->with(['device' => function ($query) {
                 $query->select('device_id', 'hostname', 'sysName');
             }])
-            ->select('mplug_id', 'mplug_type');
+            ->select('mplug_id', 'mplug_type', 'device_id');
     }
 
     public function formatItem($munin_plugin)


### PR DESCRIPTION
MuninPluginController did not ask for device_id in baseQuery, hence later it was impossible to construct valid Device model causing subsequent call to shortDisplayName in formatItem to be on NULL.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
